### PR TITLE
fixing issues around OpenApi path param issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "quoteProps": "consistent"
+}

--- a/src/restApi/createApi.ts
+++ b/src/restApi/createApi.ts
@@ -1,42 +1,20 @@
-import {
-  Express,
-  NextFunction,
-  Request,
-  RequestHandler,
-  Response,
-} from 'express';
-import {
-  RequestBody,
-  RequestParams,
-  ResponseList,
-  SuccessResponseType,
-} from './util';
+import {Express, NextFunction, Request, RequestHandler, Response} from 'express';
+import {RequestBody, RequestParams, ResponseList, SuccessResponseType} from './util';
 
-import { OpenAPIV3 } from 'openapi-types';
+import {OpenAPIV3} from 'openapi-types';
 
 /** TODO: Move to package? */
 
-export type APIDef<
-  Paths,
-  Locals extends Record<string, any>,
-  GlobalMiddleware
-> = {
+export type APIDef<Paths, Locals extends Record<string, any>, GlobalMiddleware> = {
   [path in keyof Paths]: {
-    [method in keyof Paths[path]]: OpenApiHandler<
-      Paths[path][method],
-      Locals,
-      GlobalMiddleware
-    >;
+    [method in keyof Paths[path]]: OpenApiHandler<Paths[path][method], Locals, GlobalMiddleware>;
   };
 };
 
 /**
  * Express type for a provided Open API "Operation" type
  */
-export type OpenApiRequest<
-  Operation,
-  Locals extends Record<string, any>
-> = Request<
+export type OpenApiRequest<Operation, Locals extends Record<string, any>> = Request<
   RequestParams<Operation, 'path'>, // params
   Response<ResponseList<Operation>['type']>, // response?
   RequestBody<Operation>, // body
@@ -44,39 +22,25 @@ export type OpenApiRequest<
   Locals // locals (middleware defined)
 >;
 
-export type OpenApiResponse<
-  Operation,
-  Locals extends Record<string, any>
-> = Response<ResponseList<Operation>['type'], Locals>;
+export type OpenApiResponse<Operation, Locals extends Record<string, any>> = Response<
+  ResponseList<Operation>['type'],
+  Locals
+>;
 
-export type OpenApiContext<
-  Operation,
-  Locals extends Record<string, any>,
-  GlobalMiddleware
-> = {
+export type OpenApiContext<Operation, Locals extends Record<string, any>, GlobalMiddleware> = {
   req: OpenApiRequest<Operation, Locals>;
   res: OpenApiResponse<Operation, Locals>;
-  openApi: { spec: any; operation: OpenAPIV3.OperationObject };
+  openApi: {spec: any; operation: OpenAPIV3.OperationObject};
   globalMiddleware: GlobalMiddleware;
 };
 
-export type OpenApiHandlerResponse<O> = Promise<
-  SuccessResponseType<ResponseList<O>>
->;
+export type OpenApiHandlerResponse<O> = Promise<SuccessResponseType<ResponseList<O>>>;
 
-export type OpenApiHandler<
-  Operation,
-  Locals extends Record<string, any>,
-  GlobalMiddleware
-> = (
+export type OpenApiHandler<Operation, Locals extends Record<string, any>, GlobalMiddleware> = (
   context: OpenApiContext<Operation, Locals, GlobalMiddleware>
 ) => OpenApiHandlerResponse<Operation>;
 
-export type InitOpenApiOptions<
-  Paths,
-  Locals extends Record<string, any>,
-  GlobalMiddlewareResult = {}
-> = {
+export type InitOpenApiOptions<Paths, Locals extends Record<string, any>, GlobalMiddlewareResult = {}> = {
   /**
    * The Full OpenAPI Spec (JSON).  Used to provide spec metadata to the handler & middleware
    */
@@ -90,18 +54,12 @@ export type InitOpenApiOptions<
    * The API -> router handler mapping */
   api?: APIDef<Paths, Locals, GlobalMiddlewareResult>;
 
-  errorHandler?: (
-    context: OpenApiContext<any, Locals, GlobalMiddlewareResult>,
-    err: any,
-    fn: RequestHandler
-  ) => void;
+  errorHandler?: (context: OpenApiContext<any, Locals, GlobalMiddlewareResult>, err: any, fn: RequestHandler) => void;
 
   /**
    * Middleware that runs on EVERY operation.
    * Best for security and other functions that you want to ensure always happen */
-  globalMiddleware?: (
-    context: OpenApiContext<any, Locals, undefined>
-  ) => Promise<GlobalMiddlewareResult>;
+  globalMiddleware?: (context: OpenApiContext<any, Locals, undefined>) => Promise<GlobalMiddlewareResult>;
 };
 
 /**
@@ -109,14 +67,10 @@ export type InitOpenApiOptions<
  * @param options
  * @returns
  */
-export const initApi = async <
-  Paths,
-  Locals extends Record<string, any>,
-  GlobalMiddleware
->(
+export const initApi = async <Paths, Locals extends Record<string, any>, GlobalMiddleware>(
   options: InitOpenApiOptions<Paths, Locals, GlobalMiddleware>
 ) => {
-  const { api } = options;
+  const {api} = options;
 
   const registerOperation = await createRegisterOperationFn(options);
 
@@ -136,14 +90,10 @@ export const initApi = async <
   };
 };
 
-const createRegisterOperationFn = async <
-  Paths,
-  Locals extends Record<string, any>,
-  GlobalMiddleware
->(
+const createRegisterOperationFn = async <Paths, Locals extends Record<string, any>, GlobalMiddleware>(
   options: InitOpenApiOptions<Paths, Locals, GlobalMiddleware>
 ) => {
-  const { baseUri, openApiSpec, globalMiddleware } = options;
+  const {baseUri, openApiSpec, globalMiddleware} = options;
 
   //todo: move out?
   const parsedSchema = await openApiSpec;
@@ -166,14 +116,10 @@ const createRegisterOperationFn = async <
       const operation = parsedSchema.paths[path as string][method as string];
 
       // build out context...
-      const ctx: OpenApiContext<
-        Paths[P][M],
-        Locals,
-        undefined | GlobalMiddleware
-      > = {
+      const ctx: OpenApiContext<Paths[P][M], Locals, undefined | GlobalMiddleware> = {
         req,
         res,
-        openApi: { spec: parsedSchema, operation },
+        openApi: {spec: parsedSchema, operation},
         globalMiddleware: undefined,
       };
 
@@ -197,7 +143,7 @@ const createRegisterOperationFn = async <
           //TODO do we need to check `res.headersSent`?
           const message = 'message' in err ? err.message : 'Unknown Error';
           const status = 'status' in err ? err.status : 500;
-          res.status(status).json({ message });
+          res.status(status).json({message});
         }
 
         // not sure about how next() is handled here...
@@ -207,21 +153,13 @@ const createRegisterOperationFn = async <
       }
     };
 
-    // register the handler
-    switch (method) {
-      case 'get':
-        return app.get(route, fn);
-      case 'post':
-        return app.post(route, fn);
-      case 'put':
-        return app.put(route, fn);
-      case 'delete':
-        return app.delete(route, fn);
-      case 'patch':
-        return app.patch(route, fn);
-      default:
-        throw new Error(`Unsupported method: ${method as string}`);
+    if (['get', 'post', 'put', 'delete', 'patch'].includes(method as string)) {
+      //NOTE: Express likes :param names, but OpenAPI uses {param} names
+      //So we need to conver the route to express format
+      const expressRoute = route.replace(/{/g, ':').replace(/}/g, '');
+      return app[method as keyof Express](expressRoute, fn);
     }
+    throw new Error(`Unsupported method: ${method as string}`);
   };
   return registerOperation;
 };
@@ -233,8 +171,8 @@ const createRegisterOperationFn = async <
  * @returns The first 2xx status code
  */
 function findSuccessStatusCode(operation: OpenAPIV3.OperationObject) {
-  const successStatusCodes = Object.keys(operation.responses).filter(
-    (statusCode) => String(statusCode).startsWith('2')
+  const successStatusCodes = Object.keys(operation.responses).filter((statusCode) =>
+    String(statusCode).startsWith('2')
   );
   if (successStatusCodes.length === 0) {
     return 200;
@@ -244,11 +182,9 @@ function findSuccessStatusCode(operation: OpenAPIV3.OperationObject) {
 
 export const withMiddleware =
   <O, M, Locals extends Record<string, any>, GlobalMiddleware>(
-    middleware: (
-      ctx: OpenApiContext<O, Locals, GlobalMiddleware>
-    ) => Promise<M>,
+    middleware: (ctx: OpenApiContext<O, Locals, GlobalMiddleware>) => Promise<M>,
     controller: (
-      ctx: OpenApiContext<O, Locals, GlobalMiddleware> & { middleware: M } //TODO: reactor to DRY type
+      ctx: OpenApiContext<O, Locals, GlobalMiddleware> & {middleware: M} //TODO: reactor to DRY type
     ) => OpenApiHandlerResponse<O>
   ): OpenApiHandler<O, Locals, GlobalMiddleware> =>
   async (ctx) => {


### PR DESCRIPTION
Found an issue with our OpenApi routing to express. 

OpenApi specs expect path params to be in `{param}`, like `/users/{id}`. However express expects the path params to be after a colon `:param`, like `/users/:id`

Using the `:param` in the OpenAPI spec means that when imported to swagger, the Api call out never replaces the path param with a value.

This PR allows for using `{param}` in openApi spec to be translated to express friendly  `:param`

https://swagger.io/docs/specification/describing-parameters/#path-parameters
https://expressjs.com/en/guide/routing.html